### PR TITLE
[WIP] Style: Move comments above the statements

### DIFF
--- a/src/draw.rs
+++ b/src/draw.rs
@@ -8,13 +8,16 @@ pub fn draw(buf:&Vec<u8>, cursorpos:usize, cols:usize, mode:Mode, command:&Strin
     let screenheight : usize = getmaxy(stdscr) as usize;
 
     let mut rows = buf.len() / cols;
-    if rows >= screenheight-1 { // Last line reserved for Status/Commands/etc (Like in vim)
+    // Last line reserved for Status/Commands/etc (Like in vim)
+    if rows >= screenheight-1 {
         rows = screenheight-2;
     }
 
     for z in 0 .. rows+1 {
-        printw(&format!("{:08X}: ", get_line(cols, screenoffset, z))); // 8 hex digits (4GB/cols or 0.25GB@cols=SPALTEN)
-        printw(" "); // Additional space between line number and hex
+        // 8 hex digits (4GB/cols or 0.25GB@cols=SPALTEN)
+        printw(&format!("{:08X}: ", get_line(cols, screenoffset, z)));
+        // Additional space between line number and hex
+        printw(" ");
         for s in 0 .. cols {
             let pos:usize = get_pos(cols, screenoffset, z, s);
             if pos < buf.len() {
@@ -44,39 +47,48 @@ pub fn draw(buf:&Vec<u8>, cursorpos:usize, cols:usize, mode:Mode, command:&Strin
                 printw("-- ");
             }
         }
-        printw(" "); // Additional space between hex and ascii
+        // Additional space between hex and ascii
+        printw(" ");
         for s in 0 .. cols {
             let pos:usize = get_pos(cols, screenoffset, z, s);
             color_ascii_cond(true, pos==cursorpos, cursorstate);
             if pos < buf.len() {
                 if let c @ 32...126 = buf[pos] {
                     if c as char == '%' {
-                        printw("%%"); // '%' needs to be escaped by a '%' in ncurses
+                        // '%' needs to be escaped by a '%' in ncurses
+                        printw("%%");
                     } else {
                         printw(&format!("{}", c as char) );
                     }
+                } else {
+                    // Mark non-ascii symbols
+                    printw(&format!("."));
                 }
-                else {printw(&format!(".") );} // Mark non-ascii symbols
-            } else
-            if pos == buf.len() {
-                printw(" "); // Pad ascii with spaces
+            } else if pos == buf.len() {
+                // Pad ascii with spaces
+                printw(" ");
             }
 
             color_ascii_cond(false, pos==cursorpos, cursorstate);
         }
         printw("\n");
     }
-    for _ in 0 .. screenheight-rows-2 { // TODO: check if "rows" is better
-        printw("\n"); // Put the cursor on last line of terminal
+    // TODO: check if "rows" is better
+    for _ in 0 .. screenheight-rows-2 {
+        // Put the cursor on last line of terminal
+        printw("\n");
     }
     if mode == Mode::TypeCommand {
-        printw(":"); // Indicate that a command can be typed in
+        // Indicate that a command can be typed in
+        printw(":");
     }
     if mode == Mode::Insert {
-        printw("insert"); // Indicate that insert mode is active
+        // Indicate that insert mode is active
+        printw("insert");
     }
     if mode == Mode::TypeSearch {
-        printw("/"); // indicate that the search mode is active
+        // indicate that the search mode is active
+        printw("/");
     }
     printw(&format!("{}", command));
 }

--- a/src/find.rs
+++ b/src/find.rs
@@ -7,12 +7,15 @@ impl FindSubset for Vec<u8> {
         if subset.len() > self.len() {
             return None;
         }
-        for a in 0 .. self.len() - subset.len() + 1 { //a in self.iter() { //Search in a for b
-            for b in 0 .. subset.len() { //subset.iter() {
-                if subset[b] != self[a+b] { // if b is not a, skip searching at that position in a
+        //Search in a for b
+        for a in 0 .. self.len() - subset.len() + 1 {
+            for b in 0 .. subset.len() {
+                // if b is not a, skip searching at that position in a
+                if subset[b] != self[a+b] {
                     break; // element does not match
                 }
-                if b == subset.len()-1 { // when all elements of b match in a, return position of a
+                // when all elements of b match in a, return position of a
+                if b == subset.len()-1 {
                     return Some(a);
                 }
             }
@@ -22,55 +25,64 @@ impl FindSubset for Vec<u8> {
 }
 
 #[test]
-fn find_subset_1() { // Partial at start
+// Partial at start
+fn find_subset_1() {
     let buf = vec![1,2,3,4,5];
     let sub = vec![1,2];
     assert_eq!(buf.find_subset(&sub) , Some(0));
 }
 #[test]
-fn find_subset_2() { // Partial at middle
+// Partial at middle
+fn find_subset_2() {
     let buf = vec![1,2,3,4,5];
     let sub = vec![3,4];
     assert_eq!(buf.find_subset(&sub) , Some(2));
 }
 #[test]
-fn find_subset_3() { // Partial at end
+// Partial at end
+fn find_subset_3() {
     let buf = vec![1,2,3,4,5];
     let sub = vec![4,5];
     assert_eq!(buf.find_subset(&sub) , Some(3));
 }
 #[test]
-fn find_subset_4() { // Partial after end
+// Partial after end
+fn find_subset_4() {
     let buf = vec![1,2,3,4,5];
     let sub = vec![5,6];
     assert_eq!(buf.find_subset(&sub) , None);
 }
 #[test]
-fn find_subset_5() { // Partial before start
+// Partial before start
+fn find_subset_5() {
     let buf = vec![1,2,3,4,5];
     let sub = vec![0,1];
     assert_eq!(buf.find_subset(&sub) , None);
 }
 #[test]
-fn find_subset_6() { // short
+// short
+fn find_subset_6() {
     let buf = vec![1,2,3,4,5];
     let sub = vec![2];
     assert_eq!(buf.find_subset(&sub) , Some(1));
 }
 #[test]
-fn find_subset_7() { // too long
+// too long
+fn find_subset_7() {
     let buf = vec![1,2,3,4,5];
     let sub = vec![1,2,3,4,5,6];
     assert_eq!(buf.find_subset(&sub) , None);
 }
 #[test]
-fn find_subset_8() { // full
+// full
+fn find_subset_8() {
     let buf = vec![1,2,3,4,5];
     let sub = vec![1,2,3,4,5];
     assert_eq!(buf.find_subset(&sub) , Some(0));
 }
 #[test]
-fn find_subset_9() { // Swapped
+// Swapped
+fn find_subset_9() {
     let buf = vec![1,2,3,4,5];
     let sub = vec![5,4,3,2,1];
     assert_eq!(buf.find_subset(&sub) , None);

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,14 +35,18 @@ pub enum Mode {
 fn main() {
     let mut buf = vec![];
     let mut cursorpos:usize = 0;
-    let mut cursorstate:usize = 0; //0 is left nibble, 1 is right nibble, 2 is ascii
-    let mut screenoffset:usize = 0; // 0 = display data from first line of file
+    //0 is left nibble, 1 is right nibble, 2 is ascii
+    let mut cursorstate:usize = 0;
+    // 0 = display data from first line of file
+    let mut screenoffset:usize = 0;
     const SPALTEN:usize = 16;
     let mut command = String::new();
 
-    initscr(); //start ncursesw
+    //start ncursesw
+    initscr();
     let screenheight : usize = getmaxy(stdscr) as usize;
-    cbreak();  //ctrl+z and fg works with this
+    //ctrl+z and fg works with this
+    cbreak();
     noecho();
     start_color();
     init_pair(1, COLOR_GREEN, COLOR_BLACK);


### PR DESCRIPTION
I noticed that a lot of time the comments are after a opening brace: `if foo { // comment` I find this very hard to read and would prefere the following:

```
// comment
if foo {
```

If you agree I can change it everywhere. If you don't just close the PR :wink: 

After that I could do a [`rustfmt`](https://github.com/rust-lang-nursery/rustfmt) run to automatically fix white-space issues.
